### PR TITLE
Port to Plasma 6

### DIFF
--- a/build
+++ b/build
@@ -2,9 +2,9 @@
 # Version 16
 
 ### User Variables
-qtMinVer="5.12"
-kfMinVer="5.68"
-plasmaMinVer="5.18"
+qtMinVer="6.6"
+kfMinVer="6.0"
+plasmaMinVer="6.0"
 filenameTag="-plasma${plasmaMinVer}"
 packageExt="plasmoid"
 
@@ -46,13 +46,13 @@ fi
 
 
 ### Variables
-packageNamespace=`kreadconfig5 --file="$PWD/package/metadata.desktop" --group="Desktop Entry" --key="X-KDE-PluginInfo-Name"`
+packageNamespace=`kreadconfig6 --file="$PWD/package/metadata.desktop" --group="Desktop Entry" --key="X-KDE-PluginInfo-Name"`
 packageName="${packageNamespace##*.}" # Strip namespace (Eg: "org.kde.plasma.")
-packageVersion=`kreadconfig5 --file="$PWD/package/metadata.desktop" --group="Desktop Entry" --key="X-KDE-PluginInfo-Version"`
-packageAuthor=`kreadconfig5 --file="$PWD/package/metadata.desktop" --group="Desktop Entry" --key="X-KDE-PluginInfo-Author"`
-packageAuthorEmail=`kreadconfig5 --file="$PWD/package/metadata.desktop" --group="Desktop Entry" --key="X-KDE-PluginInfo-Email"`
-packageWebsite=`kreadconfig5 --file="$PWD/package/metadata.desktop" --group="Desktop Entry" --key="X-KDE-PluginInfo-Website"`
-packageComment=`kreadconfig5 --file="$PWD/package/metadata.desktop" --group="Desktop Entry" --key="Comment"`
+packageVersion=`kreadconfig6 --file="$PWD/package/metadata.desktop" --group="Desktop Entry" --key="X-KDE-PluginInfo-Version"`
+packageAuthor=`kreadconfig6 --file="$PWD/package/metadata.desktop" --group="Desktop Entry" --key="X-KDE-PluginInfo-Author"`
+packageAuthorEmail=`kreadconfig6 --file="$PWD/package/metadata.desktop" --group="Desktop Entry" --key="X-KDE-PluginInfo-Email"`
+packageWebsite=`kreadconfig6 --file="$PWD/package/metadata.desktop" --group="Desktop Entry" --key="X-KDE-PluginInfo-Website"`
+packageComment=`kreadconfig6 --file="$PWD/package/metadata.desktop" --group="Desktop Entry" --key="Comment"`
 
 ### metadata.desktop => metadata.json
 if command -v desktoptojson &> /dev/null ; then

--- a/install
+++ b/install
@@ -4,7 +4,7 @@
 # This script detects if the widget is already installed.
 # If it is, it will use --upgrade instead and restart plasmashell.
 
-packageNamespace=`kreadconfig5 --file="$PWD/package/metadata.desktop" --group="Desktop Entry" --key="X-KDE-PluginInfo-Name"`
+packageNamespace=`kreadconfig6 --file="$PWD/package/metadata.desktop" --group="Desktop Entry" --key="X-KDE-PluginInfo-Name"`
 restartPlasmashell=false
 
 for arg in "$@"; do
@@ -16,19 +16,19 @@ for arg in "$@"; do
 done
 
 isAlreadyInstalled=false
-kpackagetool5 --type="Plasma/Applet" --show="$packageNamespace" &> /dev/null
+kpackagetool6 --type="Plasma/Applet" --show="$packageNamespace" &> /dev/null
 if [ $? == 0 ]; then
 	isAlreadyInstalled=true
 fi
 
 if $isAlreadyInstalled; then
-	kpackagetool5 -t Plasma/Applet -u package
+	kpackagetool6 -t Plasma/Applet -u package
 	restartPlasmashell=true
 else
-	kpackagetool5 -t Plasma/Applet -i package
+	kpackagetool6 -t Plasma/Applet -i package
 fi
 
 if $restartPlasmashell; then
 	killall plasmashell
-	kstart5 plasmashell
+	kstart plasmashell
 fi

--- a/package/contents/config/config.qml
+++ b/package/contents/config/config.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.0
-import org.kde.plasma.configuration 2.0
+import QtQuick 2.15
+import org.kde.plasma.configuration
 
 ConfigModel {
 	ConfigCategory {

--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<kcfg xmlns="http://www.kde.org/standards/kcfg/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.kde.org/standards/kcfg/1.0 http://www.kde.org/standards/kcfg/1.0/kcfg.xsd" >
+<kcfg xmlns="http://www.kde.org/standards/kcfg/1.0"
+			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			xsi:schemaLocation="http://www.kde.org/standards/kcfg/1.0
+			http://www.kde.org/standards/kcfg/1.0/kcfg.xsd" >
 	<kcfgfile name=""/>
 
 	<group name="General">

--- a/package/contents/ui/AppletConfig.qml
+++ b/package/contents/ui/AppletConfig.qml
@@ -1,4 +1,7 @@
-import QtQuick 2.0
+import QtQuick 2.15
+import org.kde.kirigami as Kirigami
+
+import org.kde.plasma.plasmoid
 
 QtObject {
 	id: config
@@ -7,10 +10,10 @@ QtObject {
 	function alpha(c, newAlpha) {
 		return Qt.rgba(c.r, c.g, c.b, newAlpha)
 	}
-	property color defaultEdgeColor: alpha(theme.textColor, 0.4)
-	property color defaultHoveredColor: theme.buttonBackgroundColor
-	property color defaultPressedColor: theme.buttonHoverColor
-	property color edgeColor: plasmoid.configuration.edgeColor || defaultEdgeColor
-	property color hoveredColor: plasmoid.configuration.hoveredColor || defaultHoveredColor
-	property color pressedColor: plasmoid.configuration.pressedColor || defaultPressedColor
+	property color defaultEdgeColor: alpha(Kirigami.Theme.textColor, 0.4)
+	property color defaultHoveredColor: Kirigami.Theme.backgroundColor
+	property color defaultPressedColor: Kirigami.Theme.hoverColor
+	property color edgeColor: Plasmoid.configuration.edgeColor || defaultEdgeColor
+	property color hoveredColor: Plasmoid.configuration.hoveredColor || defaultHoveredColor
+	property color pressedColor: Plasmoid.configuration.pressedColor || defaultPressedColor
 }

--- a/package/contents/ui/CommandController.qml
+++ b/package/contents/ui/CommandController.qml
@@ -1,0 +1,25 @@
+/*
+	SPDX-FileCopyrightText: 2022 ivan (@ratijas) tkachenko <me@ratijas.tk>
+
+	SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+import org.kde.plasma.plasmoid 2.0
+
+
+Controller {
+	id: controller
+
+	titleInactive: i18nc("@action:button", "Run custom command")
+	titleActive: titleInactive
+
+	descriptionActive: i18nc("@info:tooltip", "Run user-defined command when pressed")
+	descriptionInactive: descriptionActive
+
+	active: false
+
+	// override
+	function toggle() {
+		root.exec(Plasmoid.configuration.click_command);
+	}
+}

--- a/package/contents/ui/Controller.qml
+++ b/package/contents/ui/Controller.qml
@@ -1,0 +1,26 @@
+/*
+	SPDX-FileCopyrightText: 2022 ivan (@ratijas) tkachenko <me@ratijas.tk>
+
+	SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+import QtQml 2.15
+
+QtObject {
+	/**
+	 * Whether the effect is currently active, and can be deactivated.
+	 */
+	property bool active
+
+	property string titleActive
+	property string titleInactive
+
+	property string descriptionActive
+	property string descriptionInactive
+
+	readonly property string title: active ? titleActive : titleInactive
+	readonly property string description: active ? descriptionActive : descriptionInactive
+
+	// virtual
+	function toggle() {}
+}

--- a/package/contents/ui/MinimizeAllController.qml
+++ b/package/contents/ui/MinimizeAllController.qml
@@ -1,0 +1,93 @@
+/*
+	SPDX-FileCopyrightText: 2015 Sebastian Kügler <sebas@kde.org>
+	SPDX-FileCopyrightText: 2016 Anthony Fieroni <bvbfan@abv.bg>
+	SPDX-FileCopyrightText: 2018 David Edmundson <davidedmundson@kde.org>
+	SPDX-FileCopyrightText: 2022 ivan (@ratijas) tkachenko <me@ratijas.tk>
+
+	SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+import QtQml 2.15
+
+import org.kde.taskmanager 0.1 as TaskManager
+
+Controller {
+	id: controller
+
+	titleActive: i18nc("@action:button", "Restore All Minimized Windows")
+	titleInactive: i18nc("@action:button", "Minimize All Windows")
+
+	descriptionActive: i18nc("@info:tooltip", "Restores the previously minimized windows")
+	descriptionInactive: i18nc("@info:tooltip", "Shows the Desktop by minimizing all windows")
+
+	readonly property QtObject tasksModel: TaskManager.TasksModel {
+		id: tasksModel
+		sortMode: TaskManager.TasksModel.SortDisabled
+		groupMode: TaskManager.TasksModel.GroupDisabled
+	}
+
+	readonly property Connections activeTaskChangedConnection: Connections {
+		target: tasksModel
+		enabled: controller.active
+
+		function onActiveTaskChanged() {
+			if (tasksModel.activeTask.valid) { // to suppress changing focus to non windows, such as the desktop
+				controller.active = false;
+				controller.minimizedClients = [];
+			}
+		}
+
+		function onVirtualDesktopChanged() {
+			controller.deactivate();
+		}
+
+		function onActivityChanged() {
+			controller.deactivate();
+		}
+	}
+
+	/**
+	 * List of persistent model indexes from task manager model of
+	 * clients minimized by us
+	 */
+	property var minimizedClients: []
+
+	function activate() {
+		const clients = [];
+		for (let i = 0; i < tasksModel.count; i++) {
+			const idx = tasksModel.makeModelIndex(i);
+			if (!tasksModel.data(idx, TaskManager.AbstractTasksModel.IsHidden)) {
+				tasksModel.requestToggleMinimized(idx);
+				clients.push(tasksModel.makePersistentModelIndex(i));
+			}
+		}
+		minimizedClients = clients;
+		active = true;
+	}
+
+	function deactivate() {
+		active = false;
+		for (let i = 0; i < minimizedClients.length; i++) {
+			const idx = minimizedClients[i];
+			// client deleted, do nothing
+			if (!idx.valid) {
+				continue;
+			}
+			// if the user has restored it already, do nothing
+			if (!tasksModel.data(idx, TaskManager.AbstractTasksModel.IsHidden)) {
+				continue;
+			}
+			tasksModel.requestToggleMinimized(idx);
+		}
+		minimizedClients = [];
+	}
+
+	// override
+	function toggle() {
+		if (active) {
+			deactivate();
+		} else {
+			activate();
+		}
+	}
+}

--- a/package/contents/ui/PeekController.qml
+++ b/package/contents/ui/PeekController.qml
@@ -1,0 +1,30 @@
+/*
+	SPDX-FileCopyrightText: 2022 ivan (@ratijas) tkachenko <me@ratijas.tk>
+
+	SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+import org.kde.plasma.private.showdesktop 0.1
+import org.kde.plasma.plasmoid 2.0
+
+
+Controller {
+	id: controller
+
+	titleInactive: i18nc("@action:button", "Peek at Desktop")
+	titleActive: Plasmoid.containment.corona.editMode ? titleInactive : i18nc("@action:button", "Stop Peeking at Desktop")
+
+	descriptionActive: i18nc("@info:tooltip", "Moves windows back to their original positions")
+	descriptionInactive: i18nc("@info:tooltip", "Temporarily shows the desktop by moving windows away")
+
+	active: showdesktop.showingDesktop
+
+	// override
+	function toggle() {
+		showdesktop.toggleDesktop();
+	}
+
+	readonly property ShowDesktop showdesktop: ShowDesktop {
+		id: showdesktop
+	}
+}

--- a/package/contents/ui/config/ConfigGeneral.qml
+++ b/package/contents/ui/config/ConfigGeneral.qml
@@ -1,10 +1,8 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.1
 
-import QtQuick 2.0
-import QtQuick.Controls 1.0
-import QtQuick.Layouts 1.0
-import org.kde.plasma.core 2.0 as PlasmaCore
-import org.kde.plasma.components 2.0 as PlasmaComponents
-import org.kde.kirigami 2.3 as Kirigami
+import org.kde.kirigami as Kirigami
 
 import ".."
 import "../lib"
@@ -75,12 +73,12 @@ ConfigPage {
 		}
 	}
 
-	ExclusiveGroup { id: clickGroup }
+	ButtonGroup { id: clickGroup }
 	ConfigSection {
 		title: i18n("Click")
 
 		RadioButton {
-			exclusiveGroup: clickGroup
+			ButtonGroup.group: clickGroup
 			checked: cfg_click_action == 'showdesktop'
 			text: i18nd("plasma_applet_org.kde.plasma.showdesktop", "Show Desktop")
 			onClicked: {
@@ -89,7 +87,7 @@ ConfigPage {
 		}
 
 		RadioButton {
-			exclusiveGroup: clickGroup
+			ButtonGroup.group: clickGroup
 			checked: cfg_click_action == 'minimizeall'
 			text: i18ndc("plasma_applet_org.kde.plasma.showdesktop", "@action", "Minimize All Windows")
 
@@ -100,7 +98,7 @@ ConfigPage {
 
 		RadioButton {
 			id: clickGroup_runcommand
-			exclusiveGroup: clickGroup
+			ButtonGroup.group: clickGroup
 			checked: cfg_click_action == 'run_command'
 			text: i18n("Run Command")
 			onClicked: {
@@ -116,21 +114,21 @@ ConfigPage {
 			}
 		}
 		RadioButton {
-			exclusiveGroup: clickGroup
+			ButtonGroup.group: clickGroup
 			checked: false
 			text: i18nd("kwin_effects", "Toggle Present Windows (All desktops)")
 			property string command: 'qdbus org.kde.kglobalaccel /component/kwin invokeShortcut "ExposeAll"'
 			onClicked: setClickCommand(command)
 		}
 		RadioButton {
-			exclusiveGroup: clickGroup
+			ButtonGroup.group: clickGroup
 			checked: false
 			text: i18nd("kwin_effects", "Toggle Present Windows (Current desktop)")
 			property string command: 'qdbus org.kde.kglobalaccel /component/kwin invokeShortcut "Expose"'
 			onClicked: setClickCommand(command)
 		}
 		RadioButton {
-			exclusiveGroup: clickGroup
+			ButtonGroup.group: clickGroup
 			checked: false
 			text: i18nd("kwin_effects", "Toggle Present Windows (Window class)")
 			property string command: 'qdbus org.kde.kglobalaccel /component/kwin invokeShortcut "ExposeClass"'
@@ -139,14 +137,14 @@ ConfigPage {
 	}
 
 
-	ExclusiveGroup { id: mousewheelGroup }
+	ButtonGroup { id: mousewheelGroup }
 	ConfigSection {
 		title: i18n("Mouse Wheel")
 
 
 		RadioButton {
 			id: mousewheelGroup_runcommands
-			exclusiveGroup: mousewheelGroup
+			ButtonGroup.group: mousewheelGroup
 			checked: cfg_mousewheel_action == 'run_commands'
 			text: i18n("Run Commands")
 			onClicked: {
@@ -177,14 +175,14 @@ ConfigPage {
 		}
 
 		RadioButton {
-			exclusiveGroup: mousewheelGroup
+			ButtonGroup.group: mousewheelGroup
 			checked: false
 			text: i18n("Volume (No UI) (amixer)")
 			onClicked: setMouseWheelCommands('amixer -q sset Master 10%+', 'amixer -q sset Master 10%-')
 		}
 
 		RadioButton {
-			exclusiveGroup: mousewheelGroup
+			ButtonGroup.group: mousewheelGroup
 			checked: false
 			text: i18n("Volume (UI) (qdbus)")
 			property string upCommand:   'qdbus org.kde.kglobalaccel /component/kmix invokeShortcut "increase_volume"'
@@ -193,7 +191,7 @@ ConfigPage {
 		}
 
 		RadioButton {
-			exclusiveGroup: mousewheelGroup
+			ButtonGroup.group: mousewheelGroup
 			checked: false
 			text: i18n("Switch Desktop (qdbus)")
 			property string upCommand:   'qdbus org.kde.kglobalaccel /component/kwin invokeShortcut "Switch One Desktop to the Left"'
@@ -219,7 +217,7 @@ ConfigPage {
 				configKey: 'peekingThreshold'
 				suffix: i18n("ms")
 				stepSize: 50
-				minimumValue: 0
+				from: 0
 			}
 		}
 	}

--- a/package/contents/ui/lib/AppletVersion.qml
+++ b/package/contents/ui/lib/AppletVersion.qml
@@ -1,17 +1,18 @@
-import QtQuick 2.0
-import QtQuick.Controls 1.0
-import QtQuick.Layouts 1.0
-import org.kde.plasma.core 2.0 as PlasmaCore
-import org.kde.plasma.plasmoid 2.0
+import QtQuick 2.15
+import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.3
+
+import org.kde.plasma.plasma5support as Plasma5Support
+import org.kde.plasma.plasmoid
 
 Item {
 	implicitWidth: label.implicitWidth
 	implicitHeight: label.implicitHeight
 
 	property string version: "?"
-	property string metadataFilepath: plasmoid.file("", "../metadata.desktop")
+	property string metadataFilepath: Plasmoid.file("", "../metadata.desktop")
 
-	PlasmaCore.DataSource {
+	Plasma5Support.DataSource {
 		id: executable
 		engine: "executable"
 		connectedSources: []
@@ -31,7 +32,7 @@ Item {
 
 	Connections {
 		target: executable
-		onExited: {
+		function onExited() {
 			version = stdout.replace('\n', ' ').trim()
 		}
 	}

--- a/package/contents/ui/lib/AppletVersion.qml
+++ b/package/contents/ui/lib/AppletVersion.qml
@@ -42,7 +42,7 @@ Item {
 	}
 
 	Component.onCompleted: {
-		var cmd = 'kreadconfig5 --file "' + metadataFilepath + '" --group "Desktop Entry" --key "X-KDE-PluginInfo-Version"'
+		var cmd = 'kreadconfig6 --file "' + metadataFilepath + '" --group "Desktop Entry" --key "X-KDE-PluginInfo-Version"'
 		executable.exec(cmd)
 	}
 

--- a/package/contents/ui/lib/ConfigCheckBox.qml
+++ b/package/contents/ui/lib/ConfigCheckBox.qml
@@ -1,9 +1,11 @@
-import QtQuick 2.0
-import QtQuick.Controls 1.0
-import QtQuick.Layouts 1.0
+import QtQuick 2.15
+import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.3
 
-import org.kde.plasma.core 2.0 as PlasmaCore
-import org.kde.plasma.components 2.0 as PlasmaComponents
+import org.kde.plasma.core as PlasmaCore
+import org.kde.plasma.components as PlasmaComponents
+
+import org.kde.plasma.plasmoid
 
 import ".."
 
@@ -11,6 +13,6 @@ CheckBox {
 	id: configCheckBox
 
 	property string configKey: ''
-	checked: plasmoid.configuration[configKey]
-	onClicked: plasmoid.configuration[configKey] = !plasmoid.configuration[configKey]
+	checked: Plasmoid.configuration[configKey]
+	onClicked: Plasmoid.configuration[configKey] = !Plasmoid.configuration[configKey]
 }

--- a/package/contents/ui/lib/ConfigColor.qml
+++ b/package/contents/ui/lib/ConfigColor.qml
@@ -1,11 +1,14 @@
-import QtQuick 2.0
-import QtQuick.Controls 1.0
-import QtQuick.Layouts 1.0
-import QtQuick.Dialogs 1.2
-import QtQuick.Window 2.2
+import QtQuick 2.15
+import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.3
+import QtQuick.Dialogs
+import QtQuick.Window 2.12
 
-import org.kde.plasma.core 2.0 as PlasmaCore
-import org.kde.plasma.components 2.0 as PlasmaComponents
+import org.kde.plasma.core as PlasmaCore
+import org.kde.plasma.components as PlasmaComponents
+import org.kde.kirigami as Kirigami
+
+import org.kde.plasma.plasmoid
 
 import ".."
 
@@ -13,7 +16,7 @@ RowLayout {
 	id: configColor
 	spacing: 2
 	// Layout.fillWidth: true
-	Layout.maximumWidth: 300 * units.devicePixelRatio
+	Layout.maximumWidth: 300
 
 	property alias label: label.text
 	property alias horizontalAlignment: label.horizontalAlignment
@@ -22,7 +25,7 @@ RowLayout {
 	property string defaultColor: ''
 	property string value: {
 		if (configKey) {
-			return plasmoid.configuration[configKey]
+			return Plasmoid.configuration[configKey]
 		} else {
 			return "#000"
 		}
@@ -43,9 +46,9 @@ RowLayout {
 		}
 		if (configKey) {
 			if (value == defaultColorValue) {
-				plasmoid.configuration[configKey] = ""
+				Plasmoid.configuration[configKey] = ""
 			} else {
-				plasmoid.configuration[configKey] = value
+				Plasmoid.configuration[configKey] = value
 			}
 		}
 	}
@@ -73,7 +76,7 @@ RowLayout {
 			anchors.fill: parent
 			color: configColor.valueColor
 			border.width: 2
-			border.color: parent.containsMouse ? theme.highlightColor : "#BB000000"
+			border.color: parent.containsMouse ? Kirigami.Theme.highlightColor : "#BB000000"
 		}
 	}
 
@@ -98,12 +101,10 @@ RowLayout {
 		visible: false
 		modality: Qt.WindowModal
 		title: configColor.label
-		showAlphaChannel: true
-		color: configColor.valueColor
-		onCurrentColorChanged: {
-			if (visible && color != currentColor) {
-				configColor.value = currentColor
-			}
+		flags: ColorDialog.ShowAlphaChannel
+		selectedColor: configColor.valueColor
+		onAccepted: {
+			configColor.value = selectedColor
 		}
 	}
 }

--- a/package/contents/ui/lib/ConfigPage.qml
+++ b/package/contents/ui/lib/ConfigPage.qml
@@ -1,9 +1,11 @@
 // Version 4
 
-import QtQuick 2.0
-import QtQuick.Layouts 1.0
+import QtQuick 2.15
+import QtQuick.Layouts 1.3
 
-Item {
+import org.kde.kcmutils as KCM
+
+KCM.SimpleKCM {
 	id: page
 	Layout.fillWidth: true
 	default property alias _contentChildren: content.data

--- a/package/contents/ui/lib/ConfigSection.qml
+++ b/package/contents/ui/lib/ConfigSection.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.0
-import QtQuick.Controls 1.0
-import QtQuick.Layouts 1.0
+import QtQuick 2.15
+import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.3
 
 GroupBox {
 	id: configSection

--- a/package/contents/ui/lib/ConfigSpinBox.qml
+++ b/package/contents/ui/lib/ConfigSpinBox.qml
@@ -1,15 +1,15 @@
-import QtQuick 2.0
-import QtQuick.Controls 1.0
-import QtQuick.Layouts 1.0
+import QtQuick 2.15
+import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.3
+
+import org.kde.plasma.plasmoid
 
 RowLayout {
 	id: configSpinBox
 
 	property string configKey: ''
-	property alias decimals: spinBox.decimals
-	property alias horizontalAlignment: spinBox.horizontalAlignment
-	property alias maximumValue: spinBox.maximumValue
-	property alias minimumValue: spinBox.minimumValue
+	property alias to: spinBox.to
+	property alias from: spinBox.from
 	property alias prefix: spinBox.prefix
 	property alias stepSize: spinBox.stepSize
 	property alias suffix: spinBox.suffix
@@ -23,14 +23,21 @@ RowLayout {
 		text: ""
 		visible: text
 	}
-	
+
 	SpinBox {
 		id: spinBox
 
-		value: plasmoid.configuration[configKey]
-		// onValueChanged: plasmoid.configuration[configKey] = value
+		property string prefix
+		property string suffix
+
+		value: Plasmoid.configuration[configKey]
+		// onValueChanged: Plasmoid.configuration[configKey] = value
 		onValueChanged: serializeTimer.start()
-		maximumValue: 2147483647
+		to: 2147483647
+
+		textFromValue: function(value) {
+			return prefix + value + suffix;
+		}
 	}
 
 	Label {
@@ -42,6 +49,6 @@ RowLayout {
 	Timer { // throttle
 		id: serializeTimer
 		interval: 300
-		onTriggered: plasmoid.configuration[configKey] = value
+		onTriggered: Plasmoid.configuration[configKey] = value
 	}
 }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -26,8 +26,10 @@ PlasmoidItem {
 	Plasmoid.icon: "transform-move"
 	Plasmoid.title: activeController.title
 	Plasmoid.onActivated: {
-		if (peekController.active && activeController != peekController)
+		if (isPeeking) {
+			isPeeking = false;
 			peekController.toggle();
+		}
 		activeController.toggle();
 	}
 
@@ -41,6 +43,8 @@ PlasmoidItem {
 
 	Layout.preferredWidth: Layout.maximumWidth
 	Layout.preferredHeight: Layout.maximumHeight
+
+	Plasmoid.constraintHints: Plasmoid.CanFillArea
 
 	readonly property bool inPanel: [PlasmaCore.Types.TopEdge, PlasmaCore.Types.RightEdge, PlasmaCore.Types.BottomEdge, PlasmaCore.Types.LeftEdge]
 			.includes(Plasmoid.location)
@@ -65,6 +69,8 @@ PlasmoidItem {
 		}
 	}
 
+	property bool isPeeking: false
+
 	MouseArea {
 		id: mouseArea
 		anchors.fill: parent
@@ -75,13 +81,15 @@ PlasmoidItem {
 		onClicked: Plasmoid.activated();
 
 		onEntered: {
-			if (Plasmoid.configuration.peekingEnabled && !minimizeAllController.active && !peekController.active)
+			if (Plasmoid.configuration.peekingEnabled)
 				peekTimer.start();
 		}
 		onExited: {
 			peekTimer.stop();
-			if (peekController.active && !minimizeAllController.active)
+			if (isPeeking) {
+				isPeeking = false;
 				peekController.toggle();
+			}
 		}
 
 		// org.kde.plasma.volume
@@ -151,7 +159,12 @@ PlasmoidItem {
 		Timer {
 			id: peekTimer
 			interval: Plasmoid.configuration.peekingThreshold
-			onTriggered: peekController.toggle();
+			onTriggered: {
+				if (!minimizeAllController.active && !peekController.active) {
+					isPeeking = true;
+					peekController.toggle();
+				}
+			}
 		}
 
 		state: {

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -17,12 +17,12 @@
 	51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-import QtQuick 2.7
-import QtQuick.Layouts 1.1
+import QtQuick 2.15
+import QtQuick.Layouts 1.3
 
-import org.kde.plasma.plasmoid 2.0
-import org.kde.plasma.core 2.0 as PlasmaCore
-// import org.kde.plasma.components 2.0 as PlasmaComponents
+import org.kde.plasma.plasmoid
+import org.kde.plasma.core as PlasmaCore
+// import org.kde.plasma.components as PlasmaComponents
 
 import org.kde.plasma.private.showdesktop 0.1 as ShowDesktopWidget
 
@@ -47,7 +47,7 @@ Item {
 			return false
 		} else if (inLatte) { // Latte v9
 			return latteBridge.inEditMode
-		} else if (plasmoid.immutability != PlasmaCore.Types.Mutable) { // Plasma 5.17 and below
+		} else if (Plasmoid.immutability != PlasmaCore.Types.Mutable) { // Plasma 5.17 and below
 			return false
 		} else { // Plasma 5.18
 			return widget.editMode
@@ -91,7 +91,7 @@ Item {
 		if (isWidgetUnlocked) {
 			return iconSize
 		} else {
-			return Math.max(1, plasmoid.configuration.size) * units.devicePixelRatio
+			return Math.max(1, Plasmoid.configuration.size)
 		}
 	}
 
@@ -101,8 +101,8 @@ Item {
 
 	//---
 	state: {
-		if (plasmoid.formFactor == PlasmaCore.Types.Vertical) return "vertical"
-		if (plasmoid.formFactor == PlasmaCore.Types.Horizontal) return "horizontal"
+		if (Plasmoid.formFactor == PlasmaCore.Types.Vertical) return "vertical"
+		if (Plasmoid.formFactor == PlasmaCore.Types.Horizontal) return "horizontal"
 		return "square"
 	}
 
@@ -120,8 +120,8 @@ Item {
 				target: buttonRect
 				y: 0
 				x: 0
-				width: plasmoid.width
-				height: plasmoid.height
+				width: Plasmoid.width
+				height: Plasmoid.height
 			}
 			PropertyChanges {
 				target: edgeLine
@@ -134,9 +134,9 @@ Item {
 			// Assume it's on the bottom. Breeze has margins of top=4 right=5 bottom=1 left=N/A
 			PropertyChanges {
 				target: widget
-				Layout.maximumWidth: plasmoid.width
+				Layout.maximumWidth: Plasmoid.width
 				Layout.maximumHeight: widget.size // size + bottomMargin = totalHeight
-				iconSize: Math.min(plasmoid.width, units.iconSizes.smallMedium)
+				iconSize: Math.min(Plasmoid.width, units.iconSizes.smallMedium)
 			}
 			PropertyChanges {
 				target: buttonRect
@@ -159,8 +159,8 @@ Item {
 			PropertyChanges {
 				target: widget
 				Layout.maximumWidth: widget.size // size + rightMargin = totalWidth
-				Layout.maximumHeight: plasmoid.height
-				iconSize: Math.min(plasmoid.height, units.iconSizes.smallMedium)
+				Layout.maximumHeight: Plasmoid.height
+				iconSize: Math.min(Plasmoid.height, units.iconSizes.smallMedium)
 			}
 			PropertyChanges {
 				target: buttonRect
@@ -185,21 +185,21 @@ Item {
 	Plasmoid.onActivated: widget.performClick()
 
 	function performClick() {
-		if (plasmoid.configuration.click_action == 'minimizeall') {
+		if (Plasmoid.configuration.click_action == 'minimizeall') {
 			minimizeAll.toggleActive()
-		} else if (plasmoid.configuration.click_action == 'run_command') {
-			widget.exec(plasmoid.configuration.click_command)
+		} else if (Plasmoid.configuration.click_action == 'run_command') {
+			widget.exec(Plasmoid.configuration.click_command)
 		} else { // Default: showdesktop
 			showdesktop.showingDesktop = !showdesktop.showingDesktop
 		}
 	}
 
 	function performMouseWheelUp() {
-		widget.exec(plasmoid.configuration.mousewheel_up)
+		widget.exec(Plasmoid.configuration.mousewheel_up)
 	}
 
 	function performMouseWheelDown() {
-		widget.exec(plasmoid.configuration.mousewheel_down)
+		widget.exec(Plasmoid.configuration.mousewheel_down)
 	}
 
 	//--- ShowDesktop
@@ -218,7 +218,7 @@ Item {
 			// console.log('showingDesktop', showingDesktop)
 			// console.log('peekTimer.running', peekTimer.running)
 			if (!showingDesktop) {
-				if (plasmoid.configuration.peekingEnabled) {
+				if (Plasmoid.configuration.peekingEnabled) {
 					peekTimer.restart()
 				}
 			}
@@ -333,7 +333,7 @@ Item {
 
 	Timer {
 		id: peekTimer
-		interval: plasmoid.configuration.peekingThreshold
+		interval: Plasmoid.configuration.peekingThreshold
 		onTriggered: {
 			showdesktop.isPeeking = true
 		}
@@ -350,8 +350,8 @@ Item {
 
 		y: -topMargin
 		x: -leftMargin
-		width: leftMargin + plasmoid.width + rightMargin
-		height: topMargin + plasmoid.height + bottomMargin
+		width: leftMargin + Plasmoid.width + rightMargin
+		height: topMargin + Plasmoid.height + bottomMargin
 
 		Item {
 			anchors.fill: parent
@@ -408,7 +408,7 @@ Item {
 					}
 				}
 			]
-	
+
 			transitions: [
 				Transition {
 					to: "normal"
@@ -526,13 +526,13 @@ Item {
 		// Plasma 5.21 introduced a way to ignore margins.
 		// * https://invent.kde.org/frameworks/plasma-framework/-/blob/master/src/scriptengines/qml/plasmoid/appletinterface.h#L249
 		// * https://invent.kde.org/frameworks/plasma-framework/-/blob/master/src/plasma/plasma.h#L54
-		if (plasmoid.hasOwnProperty('constraintHints')) {
-			plasmoid.constraintHints = PlasmaCore.Types.CanFillArea
+		if (Plasmoid.hasOwnProperty('constraintHints')) {
+			Plasmoid.constraintHints = PlasmaCore.Types.CanFillArea
 		}
 
-		plasmoid.setAction("toggleLockWidgets", i18n("Toggle Lock Widgets"), "object-locked")
-		plasmoid.setAction("showdesktop", i18nd("plasma_applet_org.kde.plasma.showdesktop", "Show Desktop"), "user-desktop")
-		plasmoid.setAction("minimizeall", i18ndc("plasma_applet_org.kde.plasma.showdesktop", "@action", "Minimize All Windows"), "user-desktop")
+		Plasmoid.setAction("toggleLockWidgets", i18n("Toggle Lock Widgets"), "object-locked")
+		Plasmoid.setAction("showdesktop", i18nd("plasma_applet_org.kde.plasma.showdesktop", "Show Desktop"), "user-desktop")
+		Plasmoid.setAction("minimizeall", i18ndc("plasma_applet_org.kde.plasma.showdesktop", "@action", "Minimize All Windows"), "user-desktop")
 	}
 
 	//---

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -1,504 +1,279 @@
 /*
-	Copyright (C) 2019 Chris Holland <zrenfire@gmail.com>
-	Copyright (C) 2014 Ashish Madeti <ashishmadeti@gmail.com>
+	SPDX-FileCopyrightText: 2014 Ashish Madeti <ashishmadeti@gmail.com>
+	SPDX-FileCopyrightText: 2016 Kai Uwe Broulik <kde@privat.broulik.de>
+	SPDX-FileCopyrightText: 2019 Chris Holland <zrenfire@gmail.com>
+	SPDX-FileCopyrightText: 2022 ivan (@ratijas) tkachenko <me@ratijas.tk>
 
-	This program is free software; you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation; either version 2 of the License, or
-	(at your option) any later version.
-
-	This program is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
-
-	You should have received a copy of the GNU General Public License along
-	with this program; if not, write to the Free Software Foundation, Inc.,
-	51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+	SPDX-License-Identifier: GPL-2.0-or-later
 */
 
 import QtQuick 2.15
 import QtQuick.Layouts 1.3
 
-import org.kde.plasma.plasmoid
 import org.kde.plasma.core as PlasmaCore
-// import org.kde.plasma.components as PlasmaComponents
+import org.kde.plasma.plasma5support as Plasma5Support
+import org.kde.kirigami as Kirigami
+import org.kde.ksvg as KSvg
 
-import org.kde.plasma.private.showdesktop 0.1 as ShowDesktopWidget
+import org.kde.plasma.plasmoid
 
-import org.kde.draganddrop 2.0 as DragAndDrop
-import org.kde.taskmanager 0.1 as TaskManager
+PlasmoidItem {
+	id: root
 
-Item {
-	id: widget
+	preferredRepresentation: fullRepresentation
+	toolTipSubText: activeController.description
 
-	Layout.minimumWidth: Layout.maximumWidth
-	Layout.minimumHeight: Layout.maximumHeight
-
-	// In Latte, widgets are always Mutable.
-	property bool isInLatte: false // Latte v8
-	// Latte will set inEditMode=true when editing the dock.
-	// https://techbase.kde.org/LatteDock#latteBridge
-	property QtObject latteBridge: null // Latte v9
-	readonly property bool inLatte: latteBridge !== null
-
-	readonly property bool isWidgetUnlocked: {
-		if (isInLatte) { // Latte v8
-			return false
-		} else if (inLatte) { // Latte v9
-			return latteBridge.inEditMode
-		} else if (Plasmoid.immutability != PlasmaCore.Types.Mutable) { // Plasma 5.17 and below
-			return false
-		} else { // Plasma 5.18
-			return widget.editMode
-		}
+	Plasmoid.icon: "transform-move"
+	Plasmoid.title: activeController.title
+	Plasmoid.onActivated: {
+		if (peekController.active && activeController != peekController)
+			peekController.toggle();
+		activeController.toggle();
 	}
 
-	//--- containment.editMode detector
-	property var containmentInterface: null
-	readonly property bool editMode: containmentInterface ? containmentInterface.editMode : false
-	onParentChanged: {
-		if (parent) {
-			for (var obj = widget, depth = 0; !!obj; obj = obj.parent, depth++) {
-				// console.log('depth', depth, 'obj', obj)
-				if (obj.toString().startsWith('ContainmentInterface')) {
-					// desktop containment / plasmoidviewer
-					// Note: This doesn't always work. FolderViewDropArea may not yet have
-					//       ContainmentInterface as a parent when this loop runs.
-					if (typeof obj['editMode'] === 'boolean') {
-						// console.log('\t', 'obj.editMode', obj.editMode, typeof obj['editMode'])
-						widget.containmentInterface = obj
-						break
-					}
-				} else if (obj.toString().startsWith('DeclarativeDropArea')) {
-					// panel containment
-					if (typeof obj['Plasmoid'] !== 'undefined' && obj['Plasmoid'].toString().startsWith('ContainmentInterface')) {
-						if (typeof obj['Plasmoid']['editMode'] === 'boolean') {
-							// console.log('\t', 'obj.Plasmoid', obj.Plasmoid, typeof obj['Plasmoid']) // ContainmentInterface
-							// console.log('\t', 'obj.Plasmoid.editMode', obj.Plasmoid.editMode, typeof obj['Plasmoid']['editMode'])
-							widget.containmentInterface = obj.Plasmoid
-							break
-						}
-					}
-				}
-			}
-		}
-	}
+	Plasmoid.backgroundHints: PlasmaCore.Types.NoBackground
 
-	//---
-	property int iconSize: units.iconSizes.smallMedium
-	property int size: {
-		if (isWidgetUnlocked) {
-			return iconSize
+	Layout.minimumWidth: Kirigami.Units.iconSizes.medium
+	Layout.minimumHeight: Kirigami.Units.iconSizes.medium
+
+	Layout.maximumWidth: vertical ? Layout.minimumWidth : Math.max(1, Plasmoid.configuration.size)
+	Layout.maximumHeight: vertical ? Math.max(1, Plasmoid.configuration.size) : Layout.minimumHeight
+
+	Layout.preferredWidth: Layout.maximumWidth
+	Layout.preferredHeight: Layout.maximumHeight
+
+	readonly property bool inPanel: [PlasmaCore.Types.TopEdge, PlasmaCore.Types.RightEdge, PlasmaCore.Types.BottomEdge, PlasmaCore.Types.LeftEdge]
+			.includes(Plasmoid.location)
+
+	readonly property bool vertical: Plasmoid.location === PlasmaCore.Types.RightEdge || Plasmoid.location === PlasmaCore.Types.LeftEdge
+
+	readonly property Controller primaryController: {
+		if (Plasmoid.configuration.click_action == "minimizeall") {
+			return minimizeAllController;
+		} else if (Plasmoid.configuration.click_action == "showdesktop") {
+			return peekController;
 		} else {
-			return Math.max(1, Plasmoid.configuration.size)
+			return commandController;
 		}
 	}
 
-	AppletConfig {
-		id: config
-	}
-
-	//---
-	state: {
-		if (Plasmoid.formFactor == PlasmaCore.Types.Vertical) return "vertical"
-		if (Plasmoid.formFactor == PlasmaCore.Types.Horizontal) return "horizontal"
-		return "square"
-	}
-
-	states: [
-		State { name: "square"
-			PropertyChanges {
-				target: widget
-				Layout.minimumWidth: units.iconSizeHints.desktop
-				Layout.minimumHeight: units.iconSizeHints.desktop
-				Layout.maximumWidth: -1
-				Layout.maximumHeight: -1
-				iconSize: units.iconSizeHints.desktop
-			}
-			PropertyChanges {
-				target: buttonRect
-				y: 0
-				x: 0
-				width: Plasmoid.width
-				height: Plasmoid.height
-			}
-			PropertyChanges {
-				target: edgeLine
-				color: "transparent"
-				anchors.fill: edgeLine.parent
-				border.color: config.edgeColor
-			}
-		},
-		State { name: "vertical" // ...panel (fat short button)
-			// Assume it's on the bottom. Breeze has margins of top=4 right=5 bottom=1 left=N/A
-			PropertyChanges {
-				target: widget
-				Layout.maximumWidth: Plasmoid.width
-				Layout.maximumHeight: widget.size // size + bottomMargin = totalHeight
-				iconSize: Math.min(Plasmoid.width, units.iconSizes.smallMedium)
-			}
-			PropertyChanges {
-				target: buttonRect
-				rightMargin: 5
-				bottomMargin: 5
-			}
-			PropertyChanges {
-				target: edgeLine
-				height: 1 * units.devicePixelRatio
-			}
-			AnchorChanges {
-				target: edgeLine
-				anchors.left: edgeLine.parent.left
-				anchors.top: edgeLine.parent.top
-				anchors.right: edgeLine.parent.right
-			}
-		},
-		State { name: "horizontal" // ...panel (thin tall button)
-			// Assume it's on the right. Breeze has margins of top=4 right=5 bottom=1 left=N/A
-			PropertyChanges {
-				target: widget
-				Layout.maximumWidth: widget.size // size + rightMargin = totalWidth
-				Layout.maximumHeight: Plasmoid.height
-				iconSize: Math.min(Plasmoid.height, units.iconSizes.smallMedium)
-			}
-			PropertyChanges {
-				target: buttonRect
-				topMargin: 4
-				rightMargin: 5
-				bottomMargin: 3
-			}
-			PropertyChanges {
-				target: edgeLine
-				width: 1 * units.devicePixelRatio
-			}
-			AnchorChanges {
-				target: edgeLine
-				anchors.left: edgeLine.parent.left
-				anchors.top: edgeLine.parent.top
-				anchors.bottom: edgeLine.parent.bottom
-			}
-		}
-	]
-
-	Plasmoid.preferredRepresentation: Plasmoid.fullRepresentation
-	Plasmoid.onActivated: widget.performClick()
-
-	function performClick() {
-		if (Plasmoid.configuration.click_action == 'minimizeall') {
-			minimizeAll.toggleActive()
-		} else if (Plasmoid.configuration.click_action == 'run_command') {
-			widget.exec(Plasmoid.configuration.click_command)
-		} else { // Default: showdesktop
-			showdesktop.showingDesktop = !showdesktop.showingDesktop
+	readonly property Controller activeController: {
+		if (minimizeAllController.active) {
+			return minimizeAllController;
+		} else {
+			return primaryController;
 		}
 	}
 
-	function performMouseWheelUp() {
-		widget.exec(Plasmoid.configuration.mousewheel_up)
-	}
+	MouseArea {
+		id: mouseArea
+		anchors.fill: parent
 
-	function performMouseWheelDown() {
-		widget.exec(Plasmoid.configuration.mousewheel_down)
-	}
+		activeFocusOnTab: true
+		hoverEnabled: true
 
-	//--- ShowDesktop
-	// https://github.com/KDE/plasma-desktop/blob/master/applets/showdesktop/package/contents/ui/main.qml
-	ShowDesktopWidget.ShowDesktop {
-		id: showdesktop
-		property bool isPeeking: false
-		onIsPeekingChanged: {
-			if (isPeeking) {
-				showingDesktop = true
+		onClicked: Plasmoid.activated();
+
+		onEntered: {
+			if (Plasmoid.configuration.peekingEnabled && !minimizeAllController.active && !peekController.active)
+				peekTimer.start();
+		}
+		onExited: {
+			peekTimer.stop();
+			if (peekController.active && !minimizeAllController.active)
+				peekController.toggle();
+		}
+
+		// org.kde.plasma.volume
+		property int wheelDelta: 0
+		onWheel: wheel => {
+			const delta = (wheel.inverted ? -1 : 1) * (wheel.angleDelta.y ? wheel.angleDelta.y : -wheel.angleDelta.x);
+			wheelDelta += delta;
+			// Magic number 120 for common "one click"
+			// See: https://qt-project.org/doc/qt-5/qml-qtquick-wheelevent.html#angleDelta-prop
+			while (wheelDelta >= 120) {
+				wheelDelta -= 120;
+				performMouseWheelUp();
+			}
+			while (wheelDelta <= -120) {
+				wheelDelta += 120;
+				performMouseWheelDown();
 			}
 		}
 
-		function initPeeking() {
-			// console.log('initPeeking')
-			// console.log('showingDesktop', showingDesktop)
-			// console.log('peekTimer.running', peekTimer.running)
-			if (!showingDesktop) {
-				if (Plasmoid.configuration.peekingEnabled) {
-					peekTimer.restart()
-				}
+		Keys.onPressed: {
+			switch (event.key) {
+			case Qt.Key_Space:
+			case Qt.Key_Enter:
+			case Qt.Key_Return:
+			case Qt.Key_Select:
+				Plasmoid.activated();
+				break;
 			}
 		}
 
-		function cancelPeek() {
-			// console.log('cancelPeek')
-			// console.log('peekTimer.running', peekTimer.running)
-			peekTimer.stop()
-			if (isPeeking) {
-				isPeeking = false
-				showingDesktop = false
-			}
-		}
-	}
+		Accessible.name: Plasmoid.title
+		Accessible.description: toolTipSubText
+		Accessible.role: Accessible.Button
 
-	//--- MinimizeAll
-	// https://github.com/KDE/plasma-desktop/blob/master/applets/minimizeall/package/contents/ui/main.qml
-	QtObject {
-		id: minimizeAll
-		property bool active: false
-		property var minimizedClients: [] //list of persistentmodelindexes from task manager model of clients minimised by us
-
-		property var taskModel: TaskManager.TasksModel {
-			id: tasksModel
-			sortMode: TaskManager.TasksModel.SortDisabled
-			groupMode: TaskManager.TasksModel.GroupDisabled
-		}
-		property var taskModelConnection: Connections {
-			target: tasksModel
-			enabled: minimizeAll.active
-
-			onActiveTaskChanged: {
-				if (tasksModel.activeTask.valid) { //to suppress changing focus to non windows, such as the desktop
-					minimizeAll.active = false
-					minimizeAll.minimizedClients = []
-				}
-			}
-			onVirtualDesktopChanged: minimizeAll.deactivate()
-			onActivityChanged: minimizeAll.deactivate()
+		PeekController {
+			id: peekController
 		}
 
-		function logClientList(clients) {
-			for (var i = 0; i < clients.length; i++) {
-				var idx = clients[i]
-				if (!idx.valid) {
-					continue
-				}
-				console.log('  ', tasksModel.data(idx, TaskManager.AbstractTasksModel.StackingOrder), tasksModel.data(idx, TaskManager.AbstractTasksModel.AppName))
-			}
+		MinimizeAllController {
+			id: minimizeAllController
 		}
 
-		function sortByStackingOrder(clients) {
-			clients.sort(function(a, b){
-				return getClientStackingOrder(a) - getClientStackingOrder(b)
-			})
+		CommandController {
+			id: commandController
 		}
 
-		function getClientStackingOrder(idx) {
-			if (!idx.valid) {
-				return 0
-			}
-			var stackingOrder = tasksModel.data(idx, TaskManager.AbstractTasksModel.StackingOrder)
-			return stackingOrder
-		}
-
-		function activate() {
-			// console.log('activate')
-			var clients = []
-			for (var i = 0; i < tasksModel.count; i++) {
-				var idx = tasksModel.makeModelIndex(i)
-				if (!tasksModel.data(idx, TaskManager.AbstractTasksModel.IsMinimized)) {
-					tasksModel.requestToggleMinimized(idx)
-					clients.push(tasksModel.makePersistentModelIndex(i))
-				}
-			}
-			// logClientList(clients)
-			sortByStackingOrder(clients)
-			minimizedClients = clients
-			active = true
-		}
-
-		function deactivate() {
-			// console.log('deactivate')
-			// logClientList(minimizedClients)
-			active = false
-			for (var i = 0; i < minimizedClients.length; i++) {
-				var idx = minimizedClients[i]
-				// Client deleted, do nothing
-				if (!idx.valid) {
-					continue
-				}
-
-				// If the user has restored it already, do nothing
-				if (!tasksModel.data(idx, TaskManager.AbstractTasksModel.IsMinimized)) {
-					continue
-				}
-				tasksModel.requestToggleMinimized(idx)
-			}
-			minimizedClients = []
-		}
-
-		function toggleActive() {
-			if (active) {
-				deactivate()
-			} else {
-				activate()
-			}
-		}
-	}
-	//---
-
-	Timer {
-		id: peekTimer
-		interval: Plasmoid.configuration.peekingThreshold
-		onTriggered: {
-			showdesktop.isPeeking = true
-		}
-	}
-
-	Rectangle {
-		id: buttonRect
-		color: "transparent"
-
-		property int topMargin: 0
-		property int rightMargin: 0
-		property int bottomMargin: 0
-		property int leftMargin: 0
-
-		y: -topMargin
-		x: -leftMargin
-		width: leftMargin + Plasmoid.width + rightMargin
-		height: topMargin + Plasmoid.height + bottomMargin
-
-		Item {
+		Kirigami.Icon {
 			anchors.fill: parent
+			active: mouseArea.containsMouse || activeController.active
+			visible: Plasmoid.containment.corona.editMode
+			source: Plasmoid.icon
+		}
 
-			// Rectangle {
-			// 	id: surfaceNormal
-			// 	anchors.fill: parent
-			// 	anchors.topMargin: 1
-			// 	color: "transparent"
-			// 	border.color: theme.buttonBackgroundColor
-			// }
+		// also activate when dragging an item over the plasmoid so a user can easily drag data to the desktop
+		DropArea {
+			anchors.fill: parent
+			onEntered: activateTimer.start()
+			onExited: activateTimer.stop()
+		}
 
-			Rectangle {
-				id: surfaceHovered
-				anchors.fill: parent
-				anchors.topMargin: 1
-				color: config.hoveredColor
-				opacity: 0
+		Timer {
+			id: activateTimer
+			interval: 250 // to match TaskManager
+			onTriggered: Plasmoid.activated()
+		}
+
+		Timer {
+			id: peekTimer
+			interval: Plasmoid.configuration.peekingThreshold
+			onTriggered: peekController.toggle();
+		}
+
+		state: {
+			if (mouseArea.containsPress) {
+				return "pressed";
+			} else if (mouseArea.containsMouse || mouseArea.activeFocus) {
+				return "hover";
+			} else {
+				return "normal";
+			}
+		}
+
+		component ButtonSurface : Rectangle {
+			property var containerMargins: {
+				let item = this;
+				while (item.parent) {
+					item = item.parent;
+					if (item.isAppletContainer) {
+						return item.getMargins;
+					}
+				}
+				return undefined;
 			}
 
-			Rectangle {
-				id: surfacePressed
-				anchors.fill: parent
-				anchors.topMargin: 1
-				color: config.pressedColor
-				opacity: 0
+			anchors {
+				fill: parent
+				property bool returnAllMargins: true
+				// The above makes sure margin is returned even for side margins
+				// that would be otherwise turned off.
+				topMargin: !vertical && containerMargins ? -containerMargins('top', returnAllMargins) : 0
+				leftMargin: vertical && containerMargins ? -containerMargins('left', returnAllMargins) : 0
+				rightMargin: vertical && containerMargins ? -containerMargins('right', returnAllMargins) : 0
+				bottomMargin: !vertical && containerMargins ? -containerMargins('bottom', returnAllMargins) : 0
+			}
+			Behavior on opacity { OpacityAnimator { duration: Kirigami.Units.longDuration; easing.type: Easing.OutCubic } }
+		}
+
+		ButtonSurface {
+			id: hoverSurface
+			color: Plasmoid.configuration.hoveredColor
+			opacity: mouseArea.state === "hover" ? 1 : 0
+		}
+
+		ButtonSurface {
+			id: pressedSurface
+			color: Plasmoid.configuration.pressedColor
+			opacity: mouseArea.state === "pressed" ? 1 : 0
+		}
+
+		ButtonSurface {
+			id: edgeLine
+			color: "transparent"
+			border.color: Plasmoid.configuration.edgeColor
+			border.width: 1
+		}
+
+		// Active/not active indicator
+		KSvg.FrameSvgItem {
+			property var containerMargins: {
+				let item = this;
+				while (item.parent) {
+					item = item.parent;
+					if (item.isAppletContainer) {
+						return item.getMargins;
+					}
+				}
+				return undefined;
 			}
 
-			Rectangle {
-				id: edgeLine
-				color: "transparent"
-				border.color: config.edgeColor
-				border.width: 1 * units.devicePixelRatio
+			anchors {
+				fill: parent
+				property bool returnAllMargins: true
+				// The above makes sure margin is returned even for side margins
+				// that would be otherwise turned off.
+				topMargin: !vertical && containerMargins ? -containerMargins('top', returnAllMargins) : 0
+				leftMargin: vertical && containerMargins ? -containerMargins('left', returnAllMargins) : 0
+				rightMargin: vertical && containerMargins ? -containerMargins('right', returnAllMargins) : 0
+				bottomMargin: !vertical && containerMargins ? -containerMargins('bottom', returnAllMargins) : 0
 			}
-
-			state: {
-				if (control.containsPress) return "pressed"
-				if (control.containsMouse) return "hovered"
-				return "normal"
+			imagePath: "widgets/tabbar"
+			visible: opacity > 0
+			prefix: {
+				let prefix;
+				switch (Plasmoid.location) {
+				case PlasmaCore.Types.LeftEdge:
+					prefix = "west-active-tab";
+					break;
+				case PlasmaCore.Types.TopEdge:
+					prefix = "north-active-tab";
+					break;
+				case PlasmaCore.Types.RightEdge:
+					prefix = "east-active-tab";
+					break;
+				default:
+					prefix = "south-active-tab";
+				}
+				if (!hasElementPrefix(prefix)) {
+					prefix = "active-tab";
+				}
+				return prefix;
 			}
+			opacity: activeController.active ? 1 : 0
 
-			states: [
-				State { name: "normal" },
-				State { name: "hovered"
-					PropertyChanges {
-						target: surfaceHovered
-						opacity: 1
-					}
-				},
-				State { name: "pressed"
-					PropertyChanges {
-						target: surfacePressed
-						opacity: 1
-					}
-				}
-			]
-
-			transitions: [
-				Transition {
-					to: "normal"
-					//Cross fade from pressed to normal
-					ParallelAnimation {
-						NumberAnimation { target: surfaceHovered; property: "opacity"; to: 0; duration: 100 }
-						NumberAnimation { target: surfacePressed; property: "opacity"; to: 0; duration: 100 }
-					}
-				}
-			]
-
-			MouseArea {
-				id: control
-				anchors.fill: parent
-				hoverEnabled: true
-				onClicked: {
-					if (showdesktop.isPeeking && showdesktop.showingDesktop) {
-						showdesktop.isPeeking = false
-					} else {
-						peekTimer.stop()
-
-						if (true) {
-							widget.performClick()
-						} else {
-							showdesktop.showingDesktop = false
-							minimizeAll.toggleActive()
-						}
-					}
-				}
-				onEntered: {
-					// console.log('onEntered')
-					showdesktop.initPeeking()
-				}
-				onExited: {
-					// console.log('onExited')
-					showdesktop.cancelPeek()
-				}
-
-
-				// org.kde.plasma.volume
-				property int wheelDelta: 0
-				onWheel: {
-					var delta = wheel.angleDelta.y || wheel.angleDelta.x
-					wheelDelta += delta
-					// Magic number 120 for common "one click"
-					// See: http://qt-project.org/doc/qt-5/qml-qtquick-wheelevent.html#angleDelta-prop
-					while (wheelDelta >= 120) {
-						wheelDelta -= 120
-						widget.performMouseWheelUp()
-					}
-					while (wheelDelta <= -120) {
-						wheelDelta += 120
-						widget.performMouseWheelDown()
-					}
-					wheel.accepted = true
-				}
-			}
-
-			DragAndDrop.DropArea {
-				anchors.fill: parent
-				onDragEnter: {
-					// console.log('showDesktopDropArea.onDragEnter')
-					// showdesktop.initPeeking()
-					showdesktop.showingDesktop = true
+			Behavior on opacity {
+				NumberAnimation {
+					duration: Kirigami.Units.shortDuration
+					easing.type: Easing.InOutQuad
 				}
 			}
 		}
 
-		// PlasmaComponents.Button {
-		// 	anchors.fill: parent
-		// 	// anchors.left: parent.left
-		// 	// anchors.top: parent.top + 3
-		// 	// anchors.right: parent.right + 5
-		// 	// anchors.bottom: parent.bottom + 5
-		// 	// width: parent.width
-		// 	// height: parent.height
-		// 	onClicked: showdesktop.showDesktop()
-		// }
-	}
-
-	PlasmaCore.IconItem {
-		anchors.centerIn: parent
-		visible: widget.isWidgetUnlocked
-		source: "transform-move"
-		width: units.iconSizes.smallMedium
-		height: units.iconSizes.smallMedium
+		PlasmaCore.ToolTipArea {
+			id: toolTip
+			anchors.fill: parent
+			mainText: Plasmoid.title
+			subText: toolTipSubText
+			textFormat: Text.PlainText
+		}
 	}
 
 	// org.kde.plasma.mediacontrollercompact
-	PlasmaCore.DataSource {
+	Plasma5Support.DataSource {
 		id: executeSource
 		engine: "executable"
 		connectedSources: []
@@ -517,35 +292,43 @@ Item {
 			return cmd2
 		}
 	}
+
 	function exec(cmd) {
 		executeSource.connectSource(executeSource.getUniqueId(cmd))
 	}
 
+	function performMouseWheelUp() {
+		root.exec(Plasmoid.configuration.mousewheel_up)
+	}
 
-	Component.onCompleted: {
-		// Plasma 5.21 introduced a way to ignore margins.
-		// * https://invent.kde.org/frameworks/plasma-framework/-/blob/master/src/scriptengines/qml/plasmoid/appletinterface.h#L249
-		// * https://invent.kde.org/frameworks/plasma-framework/-/blob/master/src/plasma/plasma.h#L54
-		if (Plasmoid.hasOwnProperty('constraintHints')) {
-			Plasmoid.constraintHints = PlasmaCore.Types.CanFillArea
+	function performMouseWheelDown() {
+		root.exec(Plasmoid.configuration.mousewheel_down)
+	}
+
+	Plasmoid.contextualActions: [
+		PlasmaCore.Action {
+			text: i18n("Toggle Lock Widgets")
+			icon.name: "object-locked"
+			onTriggered: {
+				var cmd = 'qdbus org.kde.plasmashell /PlasmaShell evaluateScript "lockCorona(!locked)"'
+				root.exec(cmd)
+			}
+		},
+		PlasmaCore.Action {
+			text: minimizeAllController.titleInactive
+			checkable: true
+			checked: minimizeAllController.active
+			toolTip: minimizeAllController.description
+			enabled: !peekController.active
+			onTriggered: minimizeAllController.toggle()
+		},
+		PlasmaCore.Action {
+			text: peekController.titleInactive
+			checkable: true
+			checked: peekController.active
+			toolTip: peekController.description
+			enabled: !minimizeAllController.active
+			onTriggered: peekController.toggle()
 		}
-
-		Plasmoid.setAction("toggleLockWidgets", i18n("Toggle Lock Widgets"), "object-locked")
-		Plasmoid.setAction("showdesktop", i18nd("plasma_applet_org.kde.plasma.showdesktop", "Show Desktop"), "user-desktop")
-		Plasmoid.setAction("minimizeall", i18ndc("plasma_applet_org.kde.plasma.showdesktop", "@action", "Minimize All Windows"), "user-desktop")
-	}
-
-	//---
-	function action_toggleLockWidgets() {
-		var cmd = 'qdbus org.kde.plasmashell /PlasmaShell evaluateScript "lockCorona(!locked)"'
-		widget.exec(cmd)
-	}
-
-	function action_showdesktop() {
-		showdesktop.showingDesktop = true
-	}
-
-	function action_minimizeall() {
-		minimizeAll.toggleActive()
-	}
+	]
 }

--- a/package/metadata.desktop
+++ b/package/metadata.desktop
@@ -11,13 +11,12 @@ X-KDE-PluginInfo-Name=org.kde.plasma.win7showdesktop
 X-KDE-PluginInfo-Version=13
 X-KDE-PluginInfo-Website=https://github.com/Zren/plasma-applet-win7showdesktop
 X-KDE-PluginInfo-Category=Windows and Tasks
-X-KDE-PluginInfo-License=GPL
-X-Plasma-MainScript=ui/main.qml
+X-KDE-PluginInfo-License=GPL-2.0+
 X-Plasma-Provides=org.kde.plasma.windowmanagement
 
-X-Plasma-API=declarativeappletscript
-X-KDE-ServiceTypes=Plasma/Applet
+X-Plasma-API-Minimum-Version=6.0
 X-KDE-FormFactors=desktop
+KPackageStructure=Plasma/Applet
 
 
 Name[ar]=أظهر سطح المكتب (Win7)

--- a/package/translate/ReadMe.md
+++ b/package/translate/ReadMe.md
@@ -35,9 +35,9 @@ Or if you know how to make a pull request
 ## Status
 |  Locale  |  Lines  | % Done|
 |----------|---------|-------|
-| Template |      25 |       |
-| ar       |    5/25 |   20% |
-| es       |   25/25 |  100% |
-| fr       |    5/25 |   20% |
-| nl       |   25/25 |  100% |
-| pt_BR    |   20/25 |   80% |
+| Template |      35 |       |
+| ar       |    5/35 |   14% |
+| es       |   25/35 |   71% |
+| fr       |    5/35 |   14% |
+| nl       |   25/35 |   71% |
+| pt_BR    |   20/35 |   57% |

--- a/package/translate/ar.po
+++ b/package/translate/ar.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: win7showdesktop\n"
 "Report-Msgid-Bugs-To: https://github.com/Zren/plasma-applet-win7showdesktop\n"
-"POT-Creation-Date: 2023-08-16 12:36-0400\n"
+"POT-Creation-Date: 2024-03-14 18:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: ar <LL@li.org>\n"
@@ -26,6 +26,16 @@ msgstr "أظهر سطح مكتب بلازما"
 #: ../contents/config/config.qml
 msgid "General"
 msgstr "عامّ"
+
+#: ../contents/ui/CommandController.qml
+msgctxt "@action:button"
+msgid "Run custom command"
+msgstr ""
+
+#: ../contents/ui/CommandController.qml
+msgctxt "@info:tooltip"
+msgid "Run user-defined command when pressed"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Look"
@@ -113,4 +123,44 @@ msgstr ""
 
 #: ../contents/ui/main.qml
 msgid "Toggle Lock Widgets"
+msgstr ""
+
+#: ../contents/ui/MinimizeAllController.qml
+msgctxt "@action:button"
+msgid "Restore All Minimized Windows"
+msgstr ""
+
+#: ../contents/ui/MinimizeAllController.qml
+msgctxt "@action:button"
+msgid "Minimize All Windows"
+msgstr ""
+
+#: ../contents/ui/MinimizeAllController.qml
+msgctxt "@info:tooltip"
+msgid "Restores the previously minimized windows"
+msgstr ""
+
+#: ../contents/ui/MinimizeAllController.qml
+msgctxt "@info:tooltip"
+msgid "Shows the Desktop by minimizing all windows"
+msgstr ""
+
+#: ../contents/ui/PeekController.qml
+msgctxt "@action:button"
+msgid "Peek at Desktop"
+msgstr ""
+
+#: ../contents/ui/PeekController.qml
+msgctxt "@action:button"
+msgid "Stop Peeking at Desktop"
+msgstr ""
+
+#: ../contents/ui/PeekController.qml
+msgctxt "@info:tooltip"
+msgid "Moves windows back to their original positions"
+msgstr ""
+
+#: ../contents/ui/PeekController.qml
+msgctxt "@info:tooltip"
+msgid "Temporarily shows the desktop by moving windows away"
 msgstr ""

--- a/package/translate/build
+++ b/package/translate/build
@@ -6,8 +6,8 @@
 # Eg: contents/locale/fr_CA/LC_MESSAGES/plasma_applet_org.kde.plasma.eventcalendar.mo
 
 DIR=`cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd`
-plasmoidName=`kreadconfig5 --file="$DIR/../metadata.desktop" --group="Desktop Entry" --key="X-KDE-PluginInfo-Name"`
-website=`kreadconfig5 --file="$DIR/../metadata.desktop" --group="Desktop Entry" --key="X-KDE-PluginInfo-Website"`
+plasmoidName=`kreadconfig6 --file="$DIR/../metadata.desktop" --group="Desktop Entry" --key="X-KDE-PluginInfo-Name"`
+website=`kreadconfig6 --file="$DIR/../metadata.desktop" --group="Desktop Entry" --key="X-KDE-PluginInfo-Website"`
 bugAddress="$website"
 packageRoot=".." # Root of translatable sources
 projectName="plasma_applet_${plasmoidName}" # project name
@@ -46,7 +46,7 @@ echo "[build] Done building messages"
 if [ "$1" = "--restartplasma" ]; then
 	echo "[build] Restarting plasmashell"
 	killall plasmashell
-	kstart5 plasmashell
+	kstart plasmashell
 	echo "[build] Done restarting plasmashell"
 else
 	echo "[build] (re)install the plasmoid and restart plasmashell to test."

--- a/package/translate/es.po
+++ b/package/translate/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: win7showdesktop \n"
 "Report-Msgid-Bugs-To: https://github.com/Zren/plasma-applet-win7showdesktop\n"
-"POT-Creation-Date: 2023-08-16 12:36-0400\n"
+"POT-Creation-Date: 2024-03-14 18:09+0000\n"
 "PO-Revision-Date: 2019-10-19 12:36\n"
 "Last-Translator: wunivesales <universales@protonmail.com>\n"
 "Language-Team: Spanish <LL@li.org>\n"
@@ -28,6 +28,16 @@ msgstr "Mostrar el escritorio de Plasma"
 #: ../contents/config/config.qml
 msgid "General"
 msgstr "General"
+
+#: ../contents/ui/CommandController.qml
+msgctxt "@action:button"
+msgid "Run custom command"
+msgstr ""
+
+#: ../contents/ui/CommandController.qml
+msgctxt "@info:tooltip"
+msgid "Run user-defined command when pressed"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Look"
@@ -116,3 +126,43 @@ msgstr "<b>Versión:</b> %1"
 #: ../contents/ui/main.qml
 msgid "Toggle Lock Widgets"
 msgstr "Alternar widgets bloqueados"
+
+#: ../contents/ui/MinimizeAllController.qml
+msgctxt "@action:button"
+msgid "Restore All Minimized Windows"
+msgstr ""
+
+#: ../contents/ui/MinimizeAllController.qml
+msgctxt "@action:button"
+msgid "Minimize All Windows"
+msgstr ""
+
+#: ../contents/ui/MinimizeAllController.qml
+msgctxt "@info:tooltip"
+msgid "Restores the previously minimized windows"
+msgstr ""
+
+#: ../contents/ui/MinimizeAllController.qml
+msgctxt "@info:tooltip"
+msgid "Shows the Desktop by minimizing all windows"
+msgstr ""
+
+#: ../contents/ui/PeekController.qml
+msgctxt "@action:button"
+msgid "Peek at Desktop"
+msgstr ""
+
+#: ../contents/ui/PeekController.qml
+msgctxt "@action:button"
+msgid "Stop Peeking at Desktop"
+msgstr ""
+
+#: ../contents/ui/PeekController.qml
+msgctxt "@info:tooltip"
+msgid "Moves windows back to their original positions"
+msgstr ""
+
+#: ../contents/ui/PeekController.qml
+msgctxt "@info:tooltip"
+msgid "Temporarily shows the desktop by moving windows away"
+msgstr ""

--- a/package/translate/fr.po
+++ b/package/translate/fr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: win7showdesktop\n"
 "Report-Msgid-Bugs-To: https://github.com/Zren/plasma-applet-win7showdesktop\n"
-"POT-Creation-Date: 2023-08-16 12:36-0400\n"
+"POT-Creation-Date: 2024-03-14 18:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: fr <LL@li.org>\n"
@@ -26,6 +26,16 @@ msgstr "Afficher le bureau Plasma"
 #: ../contents/config/config.qml
 msgid "General"
 msgstr "Général"
+
+#: ../contents/ui/CommandController.qml
+msgctxt "@action:button"
+msgid "Run custom command"
+msgstr ""
+
+#: ../contents/ui/CommandController.qml
+msgctxt "@info:tooltip"
+msgid "Run user-defined command when pressed"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Look"
@@ -113,4 +123,44 @@ msgstr ""
 
 #: ../contents/ui/main.qml
 msgid "Toggle Lock Widgets"
+msgstr ""
+
+#: ../contents/ui/MinimizeAllController.qml
+msgctxt "@action:button"
+msgid "Restore All Minimized Windows"
+msgstr ""
+
+#: ../contents/ui/MinimizeAllController.qml
+msgctxt "@action:button"
+msgid "Minimize All Windows"
+msgstr ""
+
+#: ../contents/ui/MinimizeAllController.qml
+msgctxt "@info:tooltip"
+msgid "Restores the previously minimized windows"
+msgstr ""
+
+#: ../contents/ui/MinimizeAllController.qml
+msgctxt "@info:tooltip"
+msgid "Shows the Desktop by minimizing all windows"
+msgstr ""
+
+#: ../contents/ui/PeekController.qml
+msgctxt "@action:button"
+msgid "Peek at Desktop"
+msgstr ""
+
+#: ../contents/ui/PeekController.qml
+msgctxt "@action:button"
+msgid "Stop Peeking at Desktop"
+msgstr ""
+
+#: ../contents/ui/PeekController.qml
+msgctxt "@info:tooltip"
+msgid "Moves windows back to their original positions"
+msgstr ""
+
+#: ../contents/ui/PeekController.qml
+msgctxt "@info:tooltip"
+msgid "Temporarily shows the desktop by moving windows away"
 msgstr ""

--- a/package/translate/merge
+++ b/package/translate/merge
@@ -6,9 +6,9 @@
 # https://invent.kde.org/sysadmin/l10n-scripty/-/blob/master/extract-messages.sh
 
 DIR=`cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd`
-plasmoidName=`kreadconfig5 --file="$DIR/../metadata.desktop" --group="Desktop Entry" --key="X-KDE-PluginInfo-Name"`
+plasmoidName=`kreadconfig6 --file="$DIR/../metadata.desktop" --group="Desktop Entry" --key="X-KDE-PluginInfo-Name"`
 widgetName="${plasmoidName##*.}" # Strip namespace
-website=`kreadconfig5 --file="$DIR/../metadata.desktop" --group="Desktop Entry" --key="X-KDE-PluginInfo-Website"`
+website=`kreadconfig6 --file="$DIR/../metadata.desktop" --group="Desktop Entry" --key="X-KDE-PluginInfo-Website"`
 bugAddress="$website"
 packageRoot=".." # Root of translatable sources
 projectName="plasma_applet_${plasmoidName}" # project name

--- a/package/translate/nl.po
+++ b/package/translate/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: win7showdesktop\n"
 "Report-Msgid-Bugs-To: https://github.com/Zren/plasma-applet-win7showdesktop\n"
-"POT-Creation-Date: 2023-08-16 12:36-0400\n"
+"POT-Creation-Date: 2024-03-14 18:09+0000\n"
 "PO-Revision-Date: 2020-03-30 13:57+0200\n"
 "Last-Translator: Heimen Stoffels <vistausss@outlook.com>\n"
 "Language-Team: Dutch <vistausss@outlook.com>\n"
@@ -29,6 +29,16 @@ msgstr "Toont het Plasma-bureaublad"
 #: ../contents/config/config.qml
 msgid "General"
 msgstr "Algemeen"
+
+#: ../contents/ui/CommandController.qml
+msgctxt "@action:button"
+msgid "Run custom command"
+msgstr ""
+
+#: ../contents/ui/CommandController.qml
+msgctxt "@info:tooltip"
+msgid "Run user-defined command when pressed"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Look"
@@ -117,3 +127,43 @@ msgstr "<b>Versie:</b> %1"
 #: ../contents/ui/main.qml
 msgid "Toggle Lock Widgets"
 msgstr "Widgets ver-/ontgrendelen"
+
+#: ../contents/ui/MinimizeAllController.qml
+msgctxt "@action:button"
+msgid "Restore All Minimized Windows"
+msgstr ""
+
+#: ../contents/ui/MinimizeAllController.qml
+msgctxt "@action:button"
+msgid "Minimize All Windows"
+msgstr ""
+
+#: ../contents/ui/MinimizeAllController.qml
+msgctxt "@info:tooltip"
+msgid "Restores the previously minimized windows"
+msgstr ""
+
+#: ../contents/ui/MinimizeAllController.qml
+msgctxt "@info:tooltip"
+msgid "Shows the Desktop by minimizing all windows"
+msgstr ""
+
+#: ../contents/ui/PeekController.qml
+msgctxt "@action:button"
+msgid "Peek at Desktop"
+msgstr ""
+
+#: ../contents/ui/PeekController.qml
+msgctxt "@action:button"
+msgid "Stop Peeking at Desktop"
+msgstr ""
+
+#: ../contents/ui/PeekController.qml
+msgctxt "@info:tooltip"
+msgid "Moves windows back to their original positions"
+msgstr ""
+
+#: ../contents/ui/PeekController.qml
+msgctxt "@info:tooltip"
+msgid "Temporarily shows the desktop by moving windows away"
+msgstr ""

--- a/package/translate/pt_BR.po
+++ b/package/translate/pt_BR.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: win7showdesktop \n"
 "Report-Msgid-Bugs-To: https://github.com/Zren/plasma-applet-win7showdesktop\n"
-"POT-Creation-Date: 2023-08-16 12:36-0400\n"
+"POT-Creation-Date: 2024-03-14 18:09+0000\n"
 "PO-Revision-Date: 2020-15-01 10:25-0300\n"
 "Last-Translator: Andrew Miranda <kryptusql@protonmail.com>\n"
 "Language-Team: Portuguese Brazilian <kryptusql@protonmail.com>\n"
@@ -26,6 +26,16 @@ msgstr "Mostra a área de trabalho do Plasma"
 #: ../contents/config/config.qml
 msgid "General"
 msgstr "Geral"
+
+#: ../contents/ui/CommandController.qml
+msgctxt "@action:button"
+msgid "Run custom command"
+msgstr ""
+
+#: ../contents/ui/CommandController.qml
+msgctxt "@info:tooltip"
+msgid "Run user-defined command when pressed"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Look"
@@ -113,4 +123,44 @@ msgstr "<b>Versão:</b> %1"
 
 #: ../contents/ui/main.qml
 msgid "Toggle Lock Widgets"
+msgstr ""
+
+#: ../contents/ui/MinimizeAllController.qml
+msgctxt "@action:button"
+msgid "Restore All Minimized Windows"
+msgstr ""
+
+#: ../contents/ui/MinimizeAllController.qml
+msgctxt "@action:button"
+msgid "Minimize All Windows"
+msgstr ""
+
+#: ../contents/ui/MinimizeAllController.qml
+msgctxt "@info:tooltip"
+msgid "Restores the previously minimized windows"
+msgstr ""
+
+#: ../contents/ui/MinimizeAllController.qml
+msgctxt "@info:tooltip"
+msgid "Shows the Desktop by minimizing all windows"
+msgstr ""
+
+#: ../contents/ui/PeekController.qml
+msgctxt "@action:button"
+msgid "Peek at Desktop"
+msgstr ""
+
+#: ../contents/ui/PeekController.qml
+msgctxt "@action:button"
+msgid "Stop Peeking at Desktop"
+msgstr ""
+
+#: ../contents/ui/PeekController.qml
+msgctxt "@info:tooltip"
+msgid "Moves windows back to their original positions"
+msgstr ""
+
+#: ../contents/ui/PeekController.qml
+msgctxt "@info:tooltip"
+msgid "Temporarily shows the desktop by moving windows away"
 msgstr ""

--- a/package/translate/template.pot
+++ b/package/translate/template.pot
@@ -1,5 +1,5 @@
 # Translation of win7showdesktop in LANGUAGE
-# Copyright (C) 2023
+# Copyright (C) 2024
 # This file is distributed under the same license as the win7showdesktop package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: win7showdesktop\n"
 "Report-Msgid-Bugs-To: https://github.com/Zren/plasma-applet-win7showdesktop\n"
-"POT-Creation-Date: 2023-08-16 12:36-0400\n"
+"POT-Creation-Date: 2024-03-14 18:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -27,6 +27,16 @@ msgstr ""
 
 #: ../contents/config/config.qml
 msgid "General"
+msgstr ""
+
+#: ../contents/ui/CommandController.qml
+msgctxt "@action:button"
+msgid "Run custom command"
+msgstr ""
+
+#: ../contents/ui/CommandController.qml
+msgctxt "@info:tooltip"
+msgid "Run user-defined command when pressed"
 msgstr ""
 
 #: ../contents/ui/config/ConfigGeneral.qml
@@ -115,4 +125,44 @@ msgstr ""
 
 #: ../contents/ui/main.qml
 msgid "Toggle Lock Widgets"
+msgstr ""
+
+#: ../contents/ui/MinimizeAllController.qml
+msgctxt "@action:button"
+msgid "Restore All Minimized Windows"
+msgstr ""
+
+#: ../contents/ui/MinimizeAllController.qml
+msgctxt "@action:button"
+msgid "Minimize All Windows"
+msgstr ""
+
+#: ../contents/ui/MinimizeAllController.qml
+msgctxt "@info:tooltip"
+msgid "Restores the previously minimized windows"
+msgstr ""
+
+#: ../contents/ui/MinimizeAllController.qml
+msgctxt "@info:tooltip"
+msgid "Shows the Desktop by minimizing all windows"
+msgstr ""
+
+#: ../contents/ui/PeekController.qml
+msgctxt "@action:button"
+msgid "Peek at Desktop"
+msgstr ""
+
+#: ../contents/ui/PeekController.qml
+msgctxt "@action:button"
+msgid "Stop Peeking at Desktop"
+msgstr ""
+
+#: ../contents/ui/PeekController.qml
+msgctxt "@info:tooltip"
+msgid "Moves windows back to their original positions"
+msgstr ""
+
+#: ../contents/ui/PeekController.qml
+msgctxt "@info:tooltip"
+msgid "Temporarily shows the desktop by moving windows away"
 msgstr ""

--- a/uninstall
+++ b/uninstall
@@ -1,4 +1,4 @@
 #!/bin/bash
 # Version 1
 
-kpackagetool5 -t Plasma/Applet -r package
+kpackagetool6 -t Plasma/Applet -r package


### PR DESCRIPTION
Ported the plasmoid to Plasma 6 by basing it on the latest version of org.kde.plasma.showdesktop.
Unfortunately this does mean the vast majority of main.qml has been changed. If this is unwanted, I can try to fix the plasmoid through a general modification of the original main.qml, though my initial attempt at doing so was not so successful.
I have decided to not replace the .desktop file with a .json so as to not break the build script and version checking logic. However I did add the needed fields for Plasma 6 to the .desktop file, which will generate a valid .json file through the build script.

Known issues:
The configuration screen is a bit weird. Some things it will save just by changing the values while some others require the user to apply the changes. I think it'd be better if all changes required the user to manually apply them. If this is not intended, I'll try to provide a fix.
Rarely, bringing back the minimized windows will result in one of them being completely invisible. I don't know why this happens, as it is not consistent.
The plasmoid does not stick to the far edges of the panel, despite CanFillArea being set in the plasmoid's ConstraintHints.
AppletVersion.qml is broken.