### PR TITLE
small fix for Plasma 6.6

### DIFF
--- a/package/contents/ui/PeekController.qml
+++ b/package/contents/ui/PeekController.qml
@@ -4,9 +4,9 @@
 	SPDX-License-Identifier: GPL-2.0-or-later
 */
 
-import org.kde.plasma.private.showdesktop 0.1
+//import org.kde.plasma.private.showdesktop 0.1
+import org.kde.kwindowsystem 1.0
 import org.kde.plasma.plasmoid 2.0
-
 
 Controller {
 	id: controller
@@ -17,14 +17,17 @@ Controller {
 	descriptionActive: i18ndc("plasma_applet_org.kde.plasma.showdesktop", "@info:tooltip", "Moves windows back to their original positions")
 	descriptionInactive: i18ndc("plasma_applet_org.kde.plasma.showdesktop", "@info:tooltip", "Temporarily shows the desktop by moving windows away")
 
-	active: showdesktop.showingDesktop
+	//active: showdesktop.showingDesktop
+	active: KWindowSystem.showingDesktop
+
 
 	// override
 	function toggle() {
-		showdesktop.toggleDesktop();
+		//showdesktop.toggleDesktop();
+		KWindowSystem.showingDesktop = !KWindowSystem.showingDesktop;
 	}
 
-	readonly property ShowDesktop showdesktop: ShowDesktop {
-		id: showdesktop
-	}
+	// readonly property ShowDesktop showdesktop: ShowDesktop {
+	// 	id: showdesktop
+	// }
 }


### PR DESCRIPTION
fix PeekController.qml to support KWindowSystem in plasma 6.6
tested on 6.6, applet now works